### PR TITLE
Upgrade runtime version to 5.15

### DIFF
--- a/org.gottcode.FocusWriter.json
+++ b/org.gottcode.FocusWriter.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "org.gottcode.FocusWriter",
 	"runtime": "org.kde.Platform",
-	"runtime-version": "5.14",
+	"runtime-version": "5.15",
 	"sdk": "org.kde.Sdk",
 	"command": "focuswriter",
 	"rename-icon": "focuswriter",


### PR DESCRIPTION
This fixes crash with "protocol error" message when running on GNOME 3.36 wayland session.
The crash can be reproduced by moving mouse over menus for 5-30 seconds.
When forcing `--runtime-version=5.15` the problem goes away.
Tested on Arch and Fedora 32.